### PR TITLE
Fix Ruff lint failure

### DIFF
--- a/perspective_parquet/tests/test_all.py
+++ b/perspective_parquet/tests/test_all.py
@@ -1,4 +1,4 @@
-from perspective_parquet import *  # noqa
+from perspective_parquet import *
 
 
 def test_all():


### PR DESCRIPTION
## Description

Remove the obsolete blanket `noqa` directive from the package import test. Ruff now reports the unused suppression as RUF100; the import itself passes lint unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [ ] New tests added for new functionality
- [ ] Documentation updated (if applicable)
- [ ] Changelog / version bump (if applicable)